### PR TITLE
feat: Coqui TTS and stage name cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ Options:
   -k, --open-ai-api-key              the OpenAI API key                                                         [string]
   -g, --open-ai-model                OpenAi model : tts-1, tts-1-hd                          [string] [default: "tts-1"]
   -p, --open-ai-voice                OpenAi voice : alloy, echo, fable, onyx, nova, shimmer   [string] [default: "onyx"]
+  --use-coqui-tts                    generate missing audio item with coqui TTS             [boolean] [default: false]
+  --coqui-tts-model                  model to use with with coqui TTS                       [string] [default: "tts_models/multilingual/multi-dataset/xtts_v2"]
+  --coqui-tts-language-idx           language to use  with coqui multi TTS models            [string] [default: "fr"]
+  --coqui-tts-speaker-idx            speaker to use  with coqui multi TTS models            [string] [default: "Abrahan Mack"]
   -x, --extract                      extract a zip pack (reverse mode)                        [boolean] [default: false]
 ```
 

--- a/gen_pack.ts
+++ b/gen_pack.ts
@@ -41,6 +41,10 @@ export type ModOptions = {
   openAiApiKey?: string;
   openAiModel?: typeof OPEN_AI_MODELS[number];
   openAiVoice?: typeof OPEN_AI_VOICES[number];
+  useCoquiTts?: boolean;
+  coquiTtsModel?: string;
+  coquiTtsLanguageIdx?: string;
+  coquiTtsSpeakerIdx?: string;
   extract?: boolean;
 };
 

--- a/generate/basic_tts.ts
+++ b/generate/basic_tts.ts
@@ -62,6 +62,16 @@ export async function generate_audio_basic_tts(
       "LEF32@22050",
     ];
     await $`say ${args}`.noThrow();
+  } else if (opt.useCoquiTts) {
+    const args = [
+      "--text",
+      title,
+      "--model_name",
+      opt.coquiTtsModel,
+      "--out_path",
+      convertPath(outputPath)
+    ].concat(opt.coquiTtsLanguageIdx?["--language_idx", opt.coquiTtsLanguageIdx]:[]).concat(opt.coquiTtsSpeakerIdx?["--speaker_idx", opt.coquiTtsSpeakerIdx]:[]);
+    await $`tts ${args}`;
   } else {
     const pico2waveCommand = await getPico2waveCommand();
     const cmd = [

--- a/serialize/converter.ts
+++ b/serialize/converter.ts
@@ -9,6 +9,7 @@ import {
   ZipMenu,
 } from "./types.ts";
 import {
+  cleanStageName,
   firstStoryFile,
   getExtension,
   getFileAudioItem,
@@ -55,7 +56,7 @@ export function folderToMenu(folder: Folder, path: string): Menu {
     name: folder.name,
     okTransition: {
       class: "ActionNode",
-      name: folder.name + " ActionNode",
+      name: folder.name,
       options: folder.files
         .map((f) =>
           isFolder(f)
@@ -81,18 +82,18 @@ export function fileToZipMenu(path: string): ZipMenu {
 export function fileToStoryItem(file: File, parent: Folder): StoryItem {
   return {
     class: "StageNode-StoryItem",
-    name: file.name + " item",
+    name: cleanStageName(file.name),
     audio: getFileAudioItem(file, parent),
     image: getFileImageItem(file, parent),
     okTransition: {
-      name: file.name + " ActionNode",
+      name: cleanStageName(file.name),
       class: "ActionNode",
       options: [
         {
           class: "StageNode-Story",
           audio: getFileAudioStory(file),
           image: null,
-          name: file.name + " Stage node",
+          name: cleanStageName(file.name),
           okTransition: null,
         },
       ],
@@ -105,7 +106,7 @@ export function fileToStory(file: File): Story {
     class: "StageNode-Story",
     audio: `${file.sha1}.${getExtension(file.name)}`,
     image: null,
-    name: file.name + " Stage node",
+    name: cleanStageName(file.name),
     okTransition: null,
   };
 }

--- a/utils/parse_args.ts
+++ b/utils/parse_args.ts
@@ -178,6 +178,33 @@ export async function parseArgs(args: string[]) {
       type: "string",
       describe: "OpenAi voice : " + OPEN_AI_VOICES.join(", "),
     })
+    .option("use-coqui-tts", {
+      demandOption: false,
+      boolean: true,
+      default: false,
+      describe: "use coqui TTS",
+    })
+    .option("coqui-tts-model", {
+      demandOption: false,
+      boolean: false,
+      type: "string",
+      default: "tts_models/multilingual/multi-dataset/xtts_v2",
+      describe: "coqui TTS model",
+    })
+    .option("coqui-tts-language-idx", {
+      demandOption: false,
+      boolean: false,
+      type: "string",
+      default: "fr",
+      describe: "coqui TTS language_idx",
+    })
+    .option("coqui-tts-speaker-idx", {
+      demandOption: false,
+      boolean: false,
+      type: "string",
+      default: "Abrahan Mack",
+      describe: "coqui TTS speaker_idx",
+    })
     .option("extract", {
       alias: "x",
       demandOption: false,

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -193,3 +193,7 @@ export function rmDiacritic(s: string) {
 export function convertToValidFilename(name: string): string {
   return name.replace(/[^A-Za-zÀ-ÖØ-öø-ÿ0-9_\-.,()! ]/g, " ").trim();
 }
+
+export function cleanStageName(name: string): string {
+  return name.replace(/^\d{13} - /g, "").replace(/\.[^/.]+$/, "").trim();
+}


### PR DESCRIPTION
I added 2 things in this PR. Could make 2 but was too lazy:
* added support for Coqui TTS https://github.com/idiap/coqui-ai-TTS which is free, offline(once downloaded) and gives far better result than pico2wav
* clean up of stage names. I develop a mobile app to play studio stories. I do show stage names in many places. So it is better to have clean stage names