### PR TITLE
feat: custom script and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,8 @@
 /.idea/inspectionProfiles
 /.idea/sonarlint/
 /.idea/
-/gui/node_modules/
 /gui/src-tauri/target/
 /gui/dist
 /gui/.vite
+node_modules
+vendor

--- a/gen_pack.ts
+++ b/gen_pack.ts
@@ -116,7 +116,7 @@ export async function generatePack(opt: ModOptions) {
         folder = await fsToFolder(storyPath, true);
 
         const metadata: Metadata = await getMetadata(storyPath, opt);
-        const pack = folderToPack(folder, metadata);
+        const pack = await folderToPack(folder, metadata);
         const nightModeAudioItemName = getNightModeAudioItem(folder);
         const serializedPack = await serializePack(pack, opt, {
           autoNextStoryTransition: opt.autoNextStoryTransition,

--- a/generate/gen_image.ts
+++ b/generate/gen_image.ts
@@ -6,24 +6,22 @@ import { getConvertCommand } from "../utils/external_commands.ts";
 export async function generateImage(
   title: string,
   outputPath: string,
-  fontName: string,
+  fontName: string, 
+  extraArgs = {},
 ) {
   console.log(green(`Generate image to ${outputPath}`));
-
+  const args: Record<string, string> = Object.assign({
+    background:'black',
+    fill:'white',
+    gravity:'center',
+    size:'320x240',
+    font:fontName,
+  }, extraArgs)
   const convertCommand = await getConvertCommand();
   const cmd = [
     convertCommand[0],
     ...(convertCommand.splice(1)),
-    "-background",
-    "black",
-    "-fill",
-    "white",
-    "-gravity",
-    "center",
-    "-size",
-    "320x240",
-    "-font",
-    fontName,
+    ...Object.keys(args).map(k=>([`-${k}`, args[k] ])).flat(),
     `caption:${title}`,
     outputPath,
   ];

--- a/generate/gen_missing_items.ts
+++ b/generate/gen_missing_items.ts
@@ -78,7 +78,6 @@ export async function genMissingItems(
       } else if (isStory(file)) {
         let title = getTitle(getNameWithoutExt(file.name));
         const metadataPath  =join(rootpath, getNameWithoutExt(file.name)+ "-metadata.json");
-        console.log('metadataPath', metadataPath, await exists(metadataPath))
         if (await exists(metadataPath)) {
           try {
             const metadata =JSON.parse(await Deno.readTextFile(metadataPath))

--- a/generate/gen_missing_items.ts
+++ b/generate/gen_missing_items.ts
@@ -59,7 +59,7 @@ export async function genMissingItems(
     }
     if (!opt.skipAudioItemGen && isRoot && !getNightModeAudioItem(folder)) {
       await generateAudio(
-        i18next.t("NightModeTransition"),
+        opt.i18n?.['NightModeTransition'] || i18next.t("NightModeTransition"),
         `${rootpath}/0-night-mode.wav`,
         lang,
         opt,

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -58,7 +58,7 @@ export type FolderWithUrlOrData = {
 export type FileWithUrlOrData = File & {
   url?: string;
 } & {
-  data?: any;
+  data?: string | Uint8Array | object;
 };
 
 async function getFolderWithUrlFromRssUrl(
@@ -250,7 +250,7 @@ async function writeFileWithUrl(fileWithUrlOrData: FileWithUrlOrData, parentPath
     if (typeof toWrite === 'string') {
       toWrite = new TextEncoder().encode(toWrite)
     }
-    await Deno.writeFile(filePath, toWrite);
+    await Deno.writeFile(filePath, toWrite as Uint8Array);
   }
 }
 

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -130,7 +130,7 @@ async function getFolderWithUrlFromRssUrl(
     const fs = fss[index];
     if (imgUrl) {
       fs.files.push({
-        name: `0-item-to-resize.${getExtension(imgUrl)}`,
+        name: opt.skipImageConvert ? `0-item.${getExtension(imgUrl)}` : `0-item-to-resize.${getExtension(imgUrl)}`,
         url: imgUrl,
         sha1: "",
       });

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -12,6 +12,7 @@ import { blue, green } from "@std/fmt/colors";
 import { exists } from "@std/fs";
 import { parse } from "@libs/xml";
 import i18next from "https://deno.land/x/i18next@v23.15.1/index.js";
+import { sprintf } from "@std/fmt/printf";
 import type { File, Metadata } from "../serialize/serialize-types.ts";
 import type { ModOptions } from "../types.ts";
 import { convertImage } from "./gen_image.ts";
@@ -112,8 +113,8 @@ async function getFolderWithUrlFromRssUrl(
     const name = rssItems.length > 1
       ? `${rssName} ${
         seasonIds[index] === "0"
-          ? i18next.t("special")
-          : i18next.t("season") + " " + seasonIds[index]
+          ? opt.i18n?.['special'] || i18next.t("special")
+          : sprintf(opt.i18n?.['season'] ||  i18next.t("season"), seasonIds[index])
       }`
       : rssName;
     return {
@@ -168,7 +169,7 @@ async function getFolderOfStories(
   opt: ModOptions,
 ): Promise<FolderWithUrlOrData> {
   return {
-    name: i18next.t("storyQuestion"),
+    name: opt.i18n?.['storyQuestion'] || i18next.t("storyQuestion"),
     files: (await Promise.all(items.map(async (item) => {
       const itemFiles = [{
         name: getItemFileName(item, opt),
@@ -209,9 +210,9 @@ async function getFolderParts(
   }
 
   return {
-    name: i18next.t("partQuestion"),
+    name: opt.i18n?.['partQuestion'] || i18next.t("partQuestion"),
     files: await Promise.all(parts.map(async (part, index) => ({
-      name: `${i18next.t("partTitle")} ${index + 1}`,
+      name: sprintf( i18next.t("partTitle"),index + 1),
       files: [await getFolderOfStories(part, opt)],
     }))),
   };

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -28,6 +28,9 @@ export type Rss = {
       "@href"?: string;
     };
   };
+  "itunes:image"?: {
+    "@href": string;
+  };
   item: RssItem[];
 };
 export type RssItem = {
@@ -104,8 +107,7 @@ async function getFolderWithUrlFromRssUrl(
     rssItems = sorted.map((i) => i[1]);
   }
   const rssName = convertToValidFilename(rss.title);
-  const imgUrl = rss.image?.url || rss.itunes?.image?.["@href"] || "";
-  const fss: FolderWithUrl[] = rssItems.map((items, index) => {
+  const imgUrl = rss.image?.url || rss.itunes?.image?.["@href"] || rss["itunes:image"]?.["@href"] || "";
   const fss: FolderWithUrlOrData[] = rssItems.map((items, index) => {
     const name = rssItems.length > 1
       ? `${rssName} ${
@@ -120,7 +122,7 @@ async function getFolderWithUrlFromRssUrl(
       thumbnailUrl: opt.rssUseImageAsThumbnail
         ? items.find((item) => item["itunes:image"]?.["@href"])
           ?.["itunes:image"]?.["@href"]
-        : undefined,
+        : imgUrl,
       metadata: { ...metadata, title: name },
     };
   });

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -39,6 +39,7 @@ export type RssItem = {
   "podcast:season"?: number;
   "podcast:episode"?: number;
   "itunes:season"?: number;
+  "itunes:subtitle"?: string;
   "itunes:episode"?: number;
   "itunes:duration"?: string;
   "itunes:image"?: {
@@ -144,7 +145,7 @@ async function getFolderWithUrlFromRssUrl(
 }
 
 export function getItemFileName(item: RssItem) {
-  const title = convertToValidFilename(item.title!);
+  const title = convertToValidFilename((item['itunes:subtitle'] || item.title)!);
   return (
     new Date(item.pubDate).getTime() +
     ` - ${title}.${getExtension(item.enclosure["@url"])}`

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -149,8 +149,8 @@ async function getFolderWithUrlFromRssUrl(
   return fss;
 }
 
-export function getItemFileName(item: RssItem) {
-  const title = convertToValidFilename((item['itunes:subtitle'] || item.title)!);
+export function getItemFileName(item: RssItem, opt: ModOptions) {
+  const title = convertToValidFilename((opt.rssUseSubtitleAsTitle && item['itunes:subtitle'] || item.title)!);
   return (
     new Date(item.pubDate).getTime() +
     ` - ${title}.${getExtension(item.enclosure["@url"])}`
@@ -171,18 +171,18 @@ async function getFolderOfStories(
     name: i18next.t("storyQuestion"),
     files: (await Promise.all(items.map(async (item) => {
       const itemFiles = [{
-        name: getItemFileName(item),
+        name: getItemFileName(item, opt),
         url: fixUrl(item.enclosure["@url"]),
         sha1: "",
       }, {
-        name: getNameWithoutExt(getItemFileName(item)) + '-metadata.json',
-        data:{...item, title: item['itunes:subtitle'] || item.title},
+        name: getNameWithoutExt(getItemFileName(item, opt)) + '-metadata.json',
+        data:{...item, title: (opt.rssUseSubtitleAsTitle && item['itunes:subtitle']) || item.title},
         sha1: "",
       }];
       const imageUrl = opt.customModule?.fetchRssItemImage ? await opt.customModule?.fetchRssItemImage(item, opt):  item["itunes:image"]?.["@href"];
       if (!opt.skipRssImageDl && imageUrl) {
         itemFiles.push({
-          name: `${getNameWithoutExt(getItemFileName(item))}.item.${
+          name: `${getNameWithoutExt(getItemFileName(item, opt))}.item.${
             getExtension(imageUrl)
           }`,
           url: imageUrl,

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -170,8 +170,8 @@ async function getFolderOfStories(
         url: fixUrl(item.enclosure["@url"]),
         sha1: "",
       }];
-      const imageUrl = item["itunes:image"]?.["@href"];
-      if (!skipRssImageDl && imageUrl) {
+      const imageUrl = opt.customModule?.fetchRssItemImage ? await opt.customModule?.fetchRssItemImage(item, opt):  item["itunes:image"]?.["@href"];
+      if (!opt.skipRssImageDl && imageUrl) {
         itemFiles.push({
           name: `${getNameWithoutExt(getItemFileName(item))}.item.${
             getExtension(imageUrl)

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -10,6 +10,7 @@ import {
 import { join } from "@std/path";
 import { blue, green } from "@std/fmt/colors";
 import { exists } from "@std/fs";
+import { parse } from "https://deno.land/x/xml@2.1.3/mod.ts";
 import i18next from "https://deno.land/x/i18next@v23.15.1/index.js";
 import type { File, Metadata } from "../serialize/serialize-types.ts";
 import type { ModOptions } from "../types.ts";

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -225,9 +225,14 @@ async function writeFileWithUrl(fileWithUrl: FileWithUrl, parentPath: string) {
   if (await exists(filePath)) {
     console.log(green(`   → skip`));
   } else {
-    const resp = await fetch(fileWithUrl.url);
-    const file = await Deno.open(filePath, { create: true, write: true });
-    await resp.body?.pipeTo(file.writable);
+    if (fileWithUrl.url.startsWith('http')) {
+      const resp = await fetch(fileWithUrl.url);
+      const file = await Deno.open(filePath, { create: true, write: true });
+      await resp.body?.pipeTo(file.writable);
+    } else {
+      const file = await Deno.open(filePath, { create: true, write: true });
+      await (await Deno.open(fileWithUrl.url)).readable.pipeTo(file.writable);
+    }
   }
 }
 

--- a/serialize/serialize-types.ts
+++ b/serialize/serialize-types.ts
@@ -29,6 +29,7 @@ export type Menu = {
   path?: string;
   audioPath?: string;
   imagePath?: string;
+  duration?: number;
   audioTimestamp?: number;
   imageTimestamp?: number;
   pathTimestamp?: number;
@@ -54,6 +55,7 @@ export type StoryAction = {
 export type Story = {
   class: "StageNode-Story";
   audio: string;
+  duration?: number;
   image: null;
   name: string;
   path?: string;
@@ -64,6 +66,7 @@ export type StageNode = {
   uuid: string;
   squareOne: boolean;
   type: string;
+  duration?: number;
   name: string;
   homeTransition: { actionNode: string; optionIndex: number } | null;
   audio: string | null;

--- a/serialize/serializer.ts
+++ b/serialize/serializer.ts
@@ -227,7 +227,9 @@ async function exploreStageNode(
     type: "stage",
     uuid,
   };
-
+  if (((stageNode as Story).duration !== undefined)) {
+    serializedStageNode.duration = (stageNode as Story).duration;
+  }
   if (
     serializedStageNode.okTransition === null &&
     stageNode.class === "StageNode-Story" &&

--- a/types.ts
+++ b/types.ts
@@ -1,4 +1,4 @@
-import { RssItem } from "./generate/rss_parser.ts";
+import type { RssItem } from "./generate/rss_parser.ts";
 
 export const OPEN_AI_VOICES = [
   "alloy",

--- a/types.ts
+++ b/types.ts
@@ -1,3 +1,5 @@
+import { RssItem } from "./generate/rss_parser.ts";
+
 export const OPEN_AI_VOICES = [
   "alloy",
   "echo",
@@ -7,6 +9,10 @@ export const OPEN_AI_VOICES = [
   "shimmer",
 ] as const;
 export const OPEN_AI_MODELS = ["tts-1", "tts-1-hd"] as const;
+
+export interface CustomModule {
+  fetchRssItemImage?:(item: RssItem, opt: ModOptions) => Promise<string>
+}
 export type ModOptions = {
   storyPath: string;
   lang: string;
@@ -46,4 +52,6 @@ export type ModOptions = {
   configFile?: string;
   isCompiled?: boolean;
   gui?: boolean;
+  customScript?: string;
+  customModule?: CustomModule;
 };

--- a/types.ts
+++ b/types.ts
@@ -55,4 +55,5 @@ export type ModOptions = {
   gui?: boolean;
   customScript?: string;
   customModule?: CustomModule;
+  i18n?:Record<string, string>
 };

--- a/types.ts
+++ b/types.ts
@@ -20,6 +20,7 @@ export type ModOptions = {
   rssSplitSeasons?: boolean;
   rssMinDuration: number;
   rssUseImageAsThumbnail?: boolean;
+  rssUseSubtitleAsTitle?: boolean;
   skipImageItemGen?: boolean;
   thumbnailFromFirstItem: boolean;
   useThumbnailAsRootImage?: boolean;

--- a/utils/i18n.ts
+++ b/utils/i18n.ts
@@ -4,18 +4,18 @@ import { yellow } from "@std/fmt/colors";
 import $ from "@david/dax";
 
 const en = {
-  season: "Season",
+  season: "Season %d",
   special: "Special",
   partQuestion: "Choose your part",
-  partTitle: "Part",
+  partTitle: "Part %d",
   storyQuestion: "Choose your story",
   NightModeTransition: "Want to listen to a new story?",
 };
 const fr = {
-  season: "Saison",
+  season: "Saison %d",
   special: "Hors-Série",
   partQuestion: "Choisis ta partie",
-  partTitle: "Partie",
+  partTitle: "Partie %d",
   storyQuestion: "Choisis ton histoire",
   NightModeTransition: "Tu veux écouter une nouvelle histoire ?",
 };

--- a/utils/parse_args.ts
+++ b/utils/parse_args.ts
@@ -181,6 +181,12 @@ export async function parseArgs(args: string[]) {
       default: 0,
       describe: "RSS min episode duration",
     })
+    .option("rss-use-subtitle-as-title", {
+      demandOption: false,
+      boolean: true,
+      default: false,
+      describe: "Use rss items subtitle as title",
+    })
     .option("rss-use-image-as-thumbnail", {
       demandOption: false,
       boolean: true,

--- a/utils/parse_args.ts
+++ b/utils/parse_args.ts
@@ -319,6 +319,13 @@ export async function parseArgs(args: string[]) {
       type: "string",
       describe: "custom script to be used for custom image... handling",
     })
+    .option("i18n", {
+      demandOption: false,
+      boolean: false,
+      default: undefined,
+      type: "object",
+      describe: "custom translation options",
+    })
     .version(false)
     .demandCommand(1)
     .parse();

--- a/utils/parse_args.ts
+++ b/utils/parse_args.ts
@@ -33,6 +33,14 @@ export async function parseArgs(args: string[]) {
           opts = { ...opts, ...optsFromFile, storyPath: opts.storyPath };
         }
 
+        if (opts.customScript) {
+          try {
+            opts.customModule = await import(opts.customScript);
+          } catch (error) {
+            console.error(error);
+          }
+        }
+
         if (opts.extract) {
           return await new PackExtractor(opts).extractPack();
         } else if (opts.gui) {
@@ -297,6 +305,13 @@ export async function parseArgs(args: string[]) {
       default: false,
       hidden: true,
       describe: "true if compiled with deno compile",
+    })
+    .option("custom-script", {
+      demandOption: false,
+      boolean: false,
+      default: undefined,
+      type: "string",
+      describe: "custom script to be used for custom image... handling",
     })
     .version(false)
     .demandCommand(1)

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -228,7 +228,7 @@ export function groupBy<T>(
 }
 
 export function cleanOption(opt: ModOptions): ModOptions {
-  const cleanOpt: { [k: string]: string | number | boolean } = {};
+  const cleanOpt: { [k: string]: string | number | boolean | any } = {};
   Object.entries(opt).filter(([key]) =>
     key.length > 1 && !key.includes("-") && key != "$0"
   )

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -211,7 +211,8 @@ export function rmDiacritic(s: string) {
 }
 
 export function convertToValidFilename(name: string): string {
-  return name.replace(/[^A-Za-zÀ-ÖØ-öø-ÿ0-9_\-.,()'! ]/g, " ").trim();
+  // first we remove all unwanted chars. Then we "trim" the spaces
+  return name.replace(/[^A-Za-zÀ-ÖØ-öø-ÿ0-9_\-.,()'! ]/g, " ").replace(/\s{1,}/, " ").trim();
 }
 
 export function cleanStageName(name: string): string {

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -231,7 +231,7 @@ export function groupBy<T>(
 }
 
 export function cleanOption(opt: ModOptions): ModOptions {
-  const cleanOpt: { [k: string]: string | number | boolean | any } = {};
+  const cleanOpt: { [k: string]: string | number | boolean | object } = {};
   Object.entries(opt).filter(([key]) =>
     key.length > 1 && !key.includes("-") && key != "$0"
   )

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -76,10 +76,10 @@ export function getFolderImageItem(folder: Folder) {
 }
 
 export function getFileAudioItem(file: File, parent: Folder) {
-  const nameWithoutExt = getNameWithoutExt(file.name);
+  const nameWithoutExt = rmDiacritic(getNameWithoutExt(file.name));
   const audioItem = parent.files.find(
     (f) =>
-      getNameWithoutExt(rmDiacritic(f.name)).replace(/.item$/, "") ===
+      getNameWithoutExt(rmDiacritic(f.name)).replace(/(-generated)?.item$/, "") ===
         rmDiacritic(nameWithoutExt) &&
       fileAudioItemRegEx.test(f.name),
   ) as File;


### PR DESCRIPTION
This PR adds bug fixes and new features:
* **feature**:   you can now customize i18n from command line / config https://github.com/jersou/studio-pack-generator/pull/30/commits/a04ddda533750aeda57de11c960aae7e8ebd96ed
* **feature**:  `customScript` option: if a path to a js file is passed then it will be loaded and can be used to have custom behavior. For now the only implemented example is `fetchRssItemImage` which is used for custom fetch of rss images. In my case i use it to get episodes images from the podcast website. 
* **feature**: story audio duration added to story.json. This wont be used by lunii but can be used by "players" for easy and fast access to stories duration
* **fix**  regression for when i added `-generated` to images generated with text. The regression was causing TTS to be computed on every run ...
* **fix** : stage names and tts is now based on a metadata.json file generated with items metadata. That way we dont rely on file name which can be "simplified" compared to the original item name. The benefit is better TTS and correct names in story.json for "players"
* **fix**:  correctly query rss main image 
* **fix**:  if a podcat item has a "subtitle" use that for name. Usually better than item name (cleaner as item name often is `Podcast title: episode title`
* **fix**:  `skipImageConvert` was ignored for top level image