### PR TITLE
feat: rssEpisodeNumbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Options:
   -s, --skip-not-rss                 skip all except download RSS files                       [boolean] [default: false]
       --rss-split-length             RSS will be split in parts of N length                       [number] [default: 10]
       --rss-split-seasons            RSS create different packs per season                    [boolean] [default: false]
+      --rss-episode-numbers          add RSS episode number to stages                         [boolean] [default: false]
       --rss-min-duration             RSS min episode duration                                      [number] [default: 0]
       --rss-use-subtitle-as-title    Use rss items subtitle as title                          [boolean] [default: false]
       --rss-use-image-as-thumbnail   Use rss image (first item with image) as thumbnail       [boolean] [default: false]
@@ -362,6 +363,7 @@ Usage : `--custom-script=<path>`
 ```
 export interface CustomModule {
    fetchRssItemImage?: (item: RssItem, opt: ModOptions) => Promise<string>;
+   fetchRssItemTitle?: (item: RssItem, opt: ModOptions) => Promise<string>;
 }
 ```
 
@@ -405,6 +407,7 @@ File format (all the properties are optionals) :
   "rssMinDuration": 0,
   "rssUseImageAsThumbnail": false,
   "useThumbnailAsRootImage": false,
+  "rssEpisodeNumbers": false,
   "useCoquiTts": false,
   "coquiTtsModel": "tts_models/multilingual/multi-dataset/xtts_v2",
   "coquiTtsLanguageIdx": "fr",

--- a/common-types.ts
+++ b/common-types.ts
@@ -15,6 +15,7 @@ export type CliOptions = {
   lang: string;
   rssSplitLength: number;
   rssSplitSeasons?: boolean;
+  rssEpisodeNumbers?: boolean;
   rssMinDuration: number;
   rssUseImageAsThumbnail?: boolean;
   rssUseSubtitleAsTitle?: boolean;

--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -128,9 +128,15 @@ async function getFolderWithUrlFromRssUrl(
         ? items.find((item) => item["itunes:image"]?.["@href"])
           ?.["itunes:image"]?.["@href"]
         : imgUrl,
-      metadata: { ...metadata, title: name, ...(opt.rssEpisodeNumbers ? {
-        episodeCount: items.length
-      } :{}) },
+      metadata: {
+        ...metadata,
+        title: name,
+        ...(opt.rssEpisodeNumbers
+          ? {
+            episodeCount: items.length,
+          }
+          : {}),
+      },
     };
   });
   for (let index = 0; index < fss.length; index++) {
@@ -190,6 +196,8 @@ async function getFolderOfStories(
         name: getNameWithoutExt(getItemFileName(item, opt)) + "-metadata.json",
         data: {
           ...item,
+          episode: item["itunes:episode"] || item["podcast:episode"] ||
+            deltaIndex + index + 1,
           title: (opt.rssUseSubtitleAsTitle && item["itunes:subtitle"]) ||
             item.title,
         },
@@ -230,7 +238,13 @@ async function getFolderParts(
     name: opt.i18n?.["partQuestion"] || i18next.t("partQuestion"),
     files: await Promise.all(parts.map(async (part, index) => ({
       name: sprintf(i18next.t("partTitle"), index + 1),
-      files: [await getFolderOfStories(part, opt, parts.slice(0, index).reduce((acc, val) => acc + val.length, 0))],
+      files: [
+        await getFolderOfStories(
+          part,
+          opt,
+          parts.slice(0, index).reduce((acc, val) => acc + val.length, 0),
+        ),
+      ],
     }))),
   };
 }

--- a/serialize/converter.ts
+++ b/serialize/converter.ts
@@ -32,16 +32,18 @@ export async function folderToPack(
   folder: Folder,
   metadata?: Metadata,
 ): Promise<Pack> {
+  const { title, description, format, version, nightMode, ...otherMetadata } =
+    metadata || {};
   const firstSubFolder = folder.files.find((f) => isFolder(f)) as Folder;
   const audio = getFolderAudioItem(folder);
   const image = getFolderImageItem(folder);
   const folderPath = folder.path + "/";
   const res: Pack = {
-    title: metadata?.title ?? folder.name,
-    description: metadata?.description ?? "",
-    format: metadata?.format ?? "v1",
-    version: metadata?.version ?? 1,
-    nightModeAvailable: !!(metadata?.nightMode),
+    title: title ?? folder.name,
+    description: description ?? "",
+    format: format ?? "v1",
+    version: version ?? 1,
+    nightModeAvailable: !!nightMode,
     entrypoint: {
       class: "StageNode-Entrypoint",
       name: "Cover node",
@@ -59,6 +61,9 @@ export async function folderToPack(
             : fileToStory(firstStoryFile(folder)!),
         ],
       },
+      ...((otherMetadata && Object.keys(otherMetadata).length > 0)
+        ? { extraMetadata: otherMetadata }
+        : {}),
     },
   };
 
@@ -146,9 +151,9 @@ export async function fileToStoryItem(
   const image = getFileImageItem(file, parent);
   let name = cleanStageName(file.name);
   let metadata: {
-    title?: string
-    episode?: number
-    [k:string]: string | number | undefined
+    title?: string;
+    episode?: number;
+    [k: string]: string | number | undefined;
   } = {};
   if (parent.path) {
     const metadataPath = join(
@@ -181,12 +186,12 @@ export async function fileToStoryItem(
       options: [
         {
           class: "StageNode-Story",
-          episode: metadata.episode,
           audio: getFileAudioStory(file)?.assetName ?? null,
           duration: file.path ? (await duration(file.path)) : undefined,
           image: null,
           name,
           okTransition: null,
+          ...(metadata.episode ? { episode: metadata.episode } : {}),
         },
       ],
     },

--- a/serialize/converter.ts
+++ b/serialize/converter.ts
@@ -145,6 +145,11 @@ export async function fileToStoryItem(
   const audio = getFileAudioItem(file, parent);
   const image = getFileImageItem(file, parent);
   let name = cleanStageName(file.name);
+  let metadata: {
+    title?: string
+    episode?: number
+    [k:string]: string | number | undefined
+  } = {};
   if (parent.path) {
     const metadataPath = join(
       parent.path!,
@@ -152,7 +157,7 @@ export async function fileToStoryItem(
     );
     if (await exists(metadataPath)) {
       try {
-        const metadata = JSON.parse(await Deno.readTextFile(metadataPath));
+        metadata = JSON.parse(await Deno.readTextFile(metadataPath));
         name = metadata?.title ?? name;
       } catch (error) {
         console.error(`error reading json metadata: ${metadataPath}`, error);
@@ -176,6 +181,7 @@ export async function fileToStoryItem(
       options: [
         {
           class: "StageNode-Story",
+          episode: metadata.episode,
           audio: getFileAudioStory(file)?.assetName ?? null,
           duration: file.path ? (await duration(file.path)) : undefined,
           image: null,

--- a/serialize/serialize-types.ts
+++ b/serialize/serialize-types.ts
@@ -30,6 +30,7 @@ export type Menu = {
   audioPath?: string;
   imagePath?: string;
   duration?: number;
+  episode?: number;
   audioTimestamp?: number;
   imageTimestamp?: number;
   pathTimestamp?: number;
@@ -55,6 +56,7 @@ export type StoryAction = {
 export type Story = {
   class: "StageNode-Story";
   audio: string;
+  episode?: number;
   duration?: number;
   image: null;
   name: string;
@@ -66,6 +68,7 @@ export type StageNode = {
   uuid: string;
   squareOne: boolean;
   type: string;
+  episode?: number;
   duration?: number;
   name: string;
   homeTransition: { actionNode: string; optionIndex: number } | null;

--- a/serialize/serialize-types.ts
+++ b/serialize/serialize-types.ts
@@ -16,6 +16,7 @@ export type Pack = {
   version: number;
   nightModeAvailable: boolean;
   entrypoint: Entrypoint;
+  extraMetadata?: object;
 };
 
 export type Entrypoint = Omit<Menu, "class"> & {

--- a/serialize/serializer.ts
+++ b/serialize/serializer.ts
@@ -31,11 +31,17 @@ export async function serializePack(
   serializePackOption?: SerializePackOption,
 ): Promise<SerializedPack> {
   const serialized: SerializedPack = {
-    title: pack.title,
-    version: pack.version,
-    description: pack.description,
-    format: pack.format,
-    nightModeAvailable: pack.nightModeAvailable,
+    title: opt.metadata?.title || pack.title,
+    version: (opt.metadata?.version) || pack.version,
+    description: opt.metadata?.description || pack.description,
+    format: opt.metadata?.format || pack.format,
+    nightModeAvailable: opt.metadata?.nightModeAvailable ||
+      pack.nightModeAvailable,
+    ...(Object.assign(
+      {},
+      pack.extraMetadata ?? {},
+      opt.metadata?.extraMetadata || {},
+    )),
     actionNodes: [],
     stageNodes: [],
   };

--- a/serialize/serializer.ts
+++ b/serialize/serializer.ts
@@ -230,6 +230,9 @@ async function exploreStageNode(
   if (((stageNode as Story).duration !== undefined)) {
     serializedStageNode.duration = (stageNode as Story).duration;
   }
+  if (opt.rssEpisodeNumbers && ((stageNode as Story).episode !== undefined)) {
+    serializedStageNode.episode = (stageNode as Story).episode;
+  }
   if (
     serializedStageNode.okTransition === null &&
     stageNode.class === "StageNode-Story" &&

--- a/types.ts
+++ b/types.ts
@@ -7,5 +7,13 @@ export interface CustomModule {
 
 export type ModOptions = CliOptions & {
   customModule?: CustomModule;
+  metadata?: {
+    title?: string;
+    description?: string;
+    format?: string;
+    version?: number;
+    nightModeAvailable?: boolean;
+    [k: string]: string | number | boolean | undefined | object;
+  };
   i18n?: Record<string, string>;
 };

--- a/utils/parse_args.ts
+++ b/utils/parse_args.ts
@@ -175,6 +175,12 @@ export async function parseArgs(args: string[]) {
       default: false,
       describe: "RSS create different packs per season",
     })
+    .option("rss-episode-numbers", {
+      demandOption: false,
+      boolean: true,
+      default: false,
+      describe: "add RSS episode number to stages",
+    })
     .option("rss-min-duration", {
       demandOption: false,
       boolean: false,


### PR DESCRIPTION
This PR adds `rssEpisodeNumbers` options.
it also adds optional `metadata` to `opt` to add custom metadata to story.json (for example custom title).
I did it in the same PR as it was simpler