### PR TITLE
chore: config storyPath takes over command line one

### DIFF
--- a/utils/parse_args.ts
+++ b/utils/parse_args.ts
@@ -31,7 +31,7 @@ export async function parseArgs(args: string[]) {
           const optsFromFile = JSON.parse(
             await Deno.readTextFile(opts.configFile),
           );
-          opts = { ...opts, ...optsFromFile, storyPath: opts.storyPath };
+          opts = { ...opts, storyPath: opts.storyPath, ...optsFromFile };
         }
 
         if (opts.customScript) {


### PR DESCRIPTION
this is trick to get the storyPath set in the config.json to be used as right now commandline story path is forced in the command line (i pass " ") to get over that.