### PR TITLE
fix: add podcast metadata to generated story.json

### DIFF
--- a/generate/rss_parser.ts
+++ b/generate/rss_parser.ts
@@ -76,6 +76,7 @@ async function getFolderWithUrlFromRssUrl(
   const metadata = {
     title: rss.title,
     description: rss.description,
+    podcast: true // can be used by players to know if that pack is a podcast
   } as Metadata;
   if (opt.rssMinDuration > 0) {
     rss.item = rss.item.filter((i) => {


### PR DESCRIPTION
This requires https://github.com/jersou/studio-pack-generator/pull/31 which adds support for custom metadata