### PR TITLE
fix: add unique pack uuid for easy package update

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -17,6 +17,7 @@
     "update-frontend-assets": "cd gui/frontend && npm run build && ../gui.ts updateAssets"
   },
   "imports": {
+    "uuid-by-string": "npm:uuid-by-string",
     "@david/dax": "jsr:@david/dax@^0.42.0",
     "@dbushell/audio-duration": "jsr:@dbushell/audio-duration@^0.6.0",
     "@es-toolkit/es-toolkit": "jsr:@es-toolkit/es-toolkit@^1.23.0",

--- a/serialize/serialize-types.ts
+++ b/serialize/serialize-types.ts
@@ -96,6 +96,7 @@ export type ActionNode = {
 };
 
 export type SerializedPack = {
+  uuid: string;
   title: string;
   description: string;
   format: string;

--- a/serialize/serializer.ts
+++ b/serialize/serializer.ts
@@ -11,6 +11,7 @@ import type {
   StoryItem,
   ZipMenu,
 } from "./serialize-types.ts";
+import getUuid from "uuid-by-string";
 import { BlobReader, BlobWriter, ZipReader } from "@zip-js/zip-js";
 import type { StudioPackGenerator } from "../studio_pack_generator.ts";
 
@@ -30,6 +31,7 @@ export async function serializePack(
   serializePackOption?: SerializePackOption,
 ): Promise<SerializedPack> {
   const serialized: SerializedPack = {
+    uuid: getUuid(opt.storyPath),
     title: opt.metadata?.title || pack.title,
     version: opt.metadata?.version || pack.version,
     description: opt.metadata?.description || pack.description,

--- a/test_data/test_data.ts
+++ b/test_data/test_data.ts
@@ -69,6 +69,7 @@ export const expectedMinPack: Pack = {
 };
 
 export const expectedMinPackSerialized = {
+  uuid: "fccee86d-4b6d-5ef5-b990-55c51e7e36fe",
   title: "0-min",
   description: "",
   format: "v1",
@@ -308,6 +309,7 @@ export const expectedMoyPack: Pack = {
 };
 
 export const expectedMoyPackSerialized = {
+  uuid: "fccee86d-4b6d-5ef5-b990-55c51e7e36fe",
   title: "1-moy",
   version: 1,
   description: "",
@@ -515,6 +517,7 @@ export const expectedMoyPackSerialized = {
 };
 
 export const expectedMoyPackNextMenuSerialized = {
+  uuid: "fccee86d-4b6d-5ef5-b990-55c51e7e36fe",
   title: "1-moy",
   version: 1,
   description: "",
@@ -1195,6 +1198,7 @@ export const expectedAssetPaths = [
 ];
 
 export const expectedFullPackSerialized: SerializedPack = {
+  uuid: "c75247f5-7ed7-520f-a520-2c21d7f206a1",
   title: "2-full",
   version: 1,
   description: "",
@@ -1672,6 +1676,7 @@ export const expectedFullPackSerialized: SerializedPack = {
 };
 
 export const expectedFullPackNightSerialized = {
+  uuid: "c75247f5-7ed7-520f-a520-2c21d7f206a1",
   title: "2-full",
   version: 1,
   description: "",


### PR DESCRIPTION
Simple addition which allows to identify packs update